### PR TITLE
Added introduction to the project in the readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,6 @@ should be met:
 * node.js and npm are installed
 * Ruby (1.9+) is installed
 
-Those attempting to run the application should be comfortable using the command
-line (also known as the 'shell', or 'terminal').
-
 # Local Build Script
 
 Run the shell script:

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@
 This repository contains the code and content behind the Government Digital
 Strategy site as seen online at [http://publications.cabinetoffice.gov.uk/digital/](http://publications.cabinetoffice.gov.uk/digital/ "Government Digital Strategy online publication")
 
-By following the instructions below competent developers can set up a local,
-working, copy of the site, and view the content as it appears online.
+By following the instructions below anyone comfortable with using command line
+can set up a local, working, copy of the site, and view the content as it
+appears online.
 
 ## Prerequisites
 
@@ -15,10 +16,9 @@ should be met:
 
 * node.js and npm are installed
 * Ruby (1.9+) is installed
-* Bundle gem is installed
 
-Developers attempting to run the application should be comfortable using the
-command line (shell / terminal).
+Those attempting to run the application should be comfortable using the command
+line (also known as the 'shell', or 'terminal').
 
 # Local Build Script
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,25 @@
 *"Publish, don't send."* - Mike Bracken
 
+# What is this?
+
+This repository contains the code and content behind the Government Digital
+Strategy site as seen online at [http://publications.cabinetoffice.gov.uk/digital/](http://publications.cabinetoffice.gov.uk/digital/ "Government Digital Strategy online publication")
+
+By following the instructions below competent developers can set up a local,
+working, copy of the site, and view the content as it appears online.
+
+## Prerequisites
+
+Before attempting to install and run the application, the following prerequisites
+should be met:
+
+* node.js and npm are installed
+* Ruby (1.9+) is installed
+* Bundle gem is installed
+
+Developers attempting to run the application should be comfortable using the
+command line (shell / terminal).
+
 # Local Build Script
 
 Run the shell script:


### PR DESCRIPTION
It's not clear from the repo itself what this project relates to - so although putting it on GitHub is great, you have to dig around a bit to work out what on earth it is. To rectify  this I've added a one-sentence intro to the readme pointing to the project in the wild, so people will understand what it is.
