### PR TITLE
add TOR intro video to strategy

### DIFF
--- a/assets/sass/publication.scss
+++ b/assets/sass/publication.scss
@@ -148,6 +148,14 @@
   .mc-chart {
     @include left-margin;
   }
+  .media-player {
+    @include left-margin;
+    margin-bottom: 80px;
+    height: 500px;
+    .media-player-wrapper {
+      margin: 0;
+    }
+  }
   >.pull{
     border-top: 5px solid $colour-scheme;
     color: $colour-scheme;

--- a/assets/templates/digital_doc_template.html
+++ b/assets/templates/digital_doc_template.html
@@ -4,6 +4,7 @@
 <meta http-equiv="content-type" content="text/html; charset=UTF-8">
 <!--META-->
     {include favicon.html}
+    <link href="/assets/css/media-player.css" media="screen" rel="stylesheet" type="text/css">
     <!--[if gt IE 9]><!--><link href="/assets/css/publication.css" rel="stylesheet" type="text/css" media="screen">
 <!--<![endif]--><!--<![endif]--><!--[if IE 6]><link href="/assets/css/publication-ie6.css" rel="stylesheet" type="text/css" media="screen"><![endif]--><!--[if IE 7]><link href="/assets/css/publication-ie7.css" rel="stylesheet" type="text/css" media="screen"><![endif]--><!--[if IE 8]><link href="/assets/css/publication-ie8.css" rel="stylesheet" type="text/css" media="screen"><![endif]--><!--[if IE 9]><link href="/assets/css/publication-ie9.css" rel="stylesheet" type="text/css" media="screen"><![endif]-->
 

--- a/source/digital/strategy/02-introduction.md
+++ b/source/digital/strategy/02-introduction.md
@@ -47,3 +47,15 @@ These strategies will be published by the end of 2012, in time to
 influence departments’ 2013/14 planning process. They will set the
 framework for service transformation over the lifetime of the next
 spending review.
+
+<div class="media-player">
+<figure class="media-player-wrapper">
+  <p><a href="http://www.youtube.com/watch?v=3tnvttt_1TE" rel="external">Watch on YouTube</a>
+  <a class="captions" href="transcript.xml">Captions</a></p>
+</figure>
+</div>
+<p><a href="http://www.youtube.com/watch?v=3tnvttt_1TE" rel="external">Watch on YouTube</a></p>
+
+Watch Tim O’Reilly, the founder and CEO of O'Reilly Media, talk about the
+importance of focusing on user needs and how the Government Digital Strategy
+is “inspiring” because of its focus on user centred design.

--- a/source/digital/strategy/case-studies/government-as-platform/index.html
+++ b/source/digital/strategy/case-studies/government-as-platform/index.html
@@ -31,6 +31,7 @@
 </div>
 
 <div class="section">
+  <p>According to Tim O’Reilly ‘government needs to start thinking about itself as a platform’. And Tim’s opinion matters, as the founder and CEO of O'Reilly Media - one of the world’s most respected computer book publishers.</p>
   <div class="pull">
     <p><strong>Tim O'Reilly</strong> is Founder and CEO of O'Reilly Media</p>
   </div>

--- a/source/partials/case-studies/_government-as-a-platform-2.md
+++ b/source/partials/case-studies/_government-as-a-platform-2.md
@@ -1,5 +1,3 @@
-According to Tim O’Reilly ‘government needs to start thinking about itself as a platform’. And Tim’s opinion matters, as the founder and CEO of O'Reilly Media - one of the world’s most respected computer book publishers.
-
 Tim believes that government is right in wanting to create service end points that will allow outside developers to build applications against its data. Why? “Because it enables you build web services rather than just websites and apps, and when you publish those end points it enables people to use government data in a way that nobody expected”. For Tim, “that’s when you get that incredible revolution”.
 
 He gives an example of how Apple rethought the mobile phone, with companies going from sitting down with a couple of developers and coming up with 30 applications for a phone, to Apple creating a platform which has resulted in more than 700,000 applications being created for the iPhone.


### PR DESCRIPTION
This adds the Tim O'Reilly video to the Introduction section of the digital strategy.
