### PR TITLE
add offline build script

### DIFF
--- a/offline-build.sh
+++ b/offline-build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+ruby compiling/build.rb $1 --trace


### PR DESCRIPTION
We have the assisted digital in another repository - and soon more content will end up in its own repository, away from the code (which is good).

However this means to test a change to the Assisted Digital paper, you have to.

1) Change the stuff in the AD repository
2) Push this live
3) Run `./local-build.sh`

Sometimes you want to be able to edit the AD content you have locally, without having to push.

So this adds `./offline-build.sh` which builds purely from what you have at that time within `source/`, and doesn't pull anything in from the internet. This is also useful if you're on a train and working, or something.
